### PR TITLE
Kniepbert

### DIFF
--- a/libibtool/discovery.py
+++ b/libibtool/discovery.py
@@ -324,7 +324,7 @@ def print_switch(sbn,args,switch):
             rhs = '[  ] "" ( )';
         else:
             rhs = "%3d %4d[  ] %s"%(
-                peer_port.to_end_port().LID, peer_port.to_end_port().port_id,
+                peer_port.to_end_port().LID, peer_port.port_id,
                 IBA_describe.dstr(peer_port.parent.desc,True));
 
 	    if better_possible(pinf.linkWidthSupported,peer_port.pinf.linkWidthSupported,


### PR DESCRIPTION
Hey Folks,

pretty neat tool. Thats the next step in IB-maintaining.. :) I talk to your CVO David at ISC in Hamburg. 
Just a few bugs we have to fix in iblinkinfo, right? 
In interswitch connections the destination port refered to port0. 
If I get it right that is because port0 handles all the good stuff (lid,...). But therefor port0 does not have all the interesting information like 'port_id of remote port' and alike.

I am just starting digging into it. Maybe the port-creation has to clone port0 and inherit all the good information?
kind like
### 

class switch_port0(object):
  _jadah jadah_
class switch_portX(switch_port0):
  _and so on_
### 

what do you say? 

Cheers 
Christian
